### PR TITLE
Getting user ID from token, preventing certain edits to prescriptions, fixes to create_user_activity(), create_inventory_update(), and fill prescription

### DIFF
--- a/backend/api_server/backend.py
+++ b/backend/api_server/backend.py
@@ -676,7 +676,7 @@ def create_user_activity(user_activity: UserActivityCreate, db: Session, current
     db_user_activity = models.UserActivity(
         # get user_id from current_user
         user_id=current_user.id,
-        activity=user_activity.activity,
+        type=user_activity.type,
         timestamp=datetime.now(timezone.utc) # set the timestamp in UTC so timezones don't affect it
     )
 

--- a/backend/api_server/backend.py
+++ b/backend/api_server/backend.py
@@ -474,10 +474,26 @@ def get_prescription(prescription_id: int, db: Session = Depends(get_db), curren
 
 # create prescription
 @app.post("/prescription", response_model=schema.PrescriptionResponse)
-def create_prescription(prescription: schema.PrescriptionCreate, db: Session = Depends(get_db), current_user: UserToReturn = Depends(get_current_user)):
+def create_prescription(
+    prescription: schema.PrescriptionCreate,
+    db: Session = Depends(get_db),
+    current_user: UserToReturn = Depends(get_current_user),
+):
     # Ensure that prescription data is valid
     try:
-        db_prescription = models.Prescription(**prescription.model_dump())  # Use .model_dump() for Pydantic V2
+        # db_prescription = models.Prescription(**prescription.model_dump())  # Use .model_dump() for Pydantic V2
+
+        # not all the fields needed for the DB come from PrescriptionCreate (user_entered_id)
+        # so we need to add it here
+        db_prescription = models.Prescription(
+            patient_id=prescription.patient_id,
+            # get the user who entered the prescription from the current user
+            user_entered_id=current_user.id,
+            medication_id=prescription.id,
+            doctor_name=prescription.doctor_name,
+            quantity=prescription.quantity,  # The number of units of medication that this prescription allows the patient to get
+        )
+
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 

--- a/backend/api_server/backend.py
+++ b/backend/api_server/backend.py
@@ -595,7 +595,7 @@ def fill_prescription(prescription_id: int, db: Session = Depends(get_db), curre
         
         # set the timestamp of filling to the current time
         db_prescription.filled_timestamp = datetime.now()
-        # get the user who filled the prescription from the current user
+        # get the user_id of the user who filled the prescription from the current user
         db_prescription.user_filled_id = current_user.id
 
     db.commit()

--- a/backend/api_server/backend.py
+++ b/backend/api_server/backend.py
@@ -585,7 +585,7 @@ def fill_prescription(prescription_id: int, db: Session = Depends(get_db), curre
 
         # send the inventory_update_request to actually be stored in the database
         # this will add an entry to user_activities (for filling the prescription) for us
-        create_inventory_update(inventory_update=inventory_update_request, db=db)
+        create_inventory_update(inventory_update=inventory_update_request, db=db, current_user=current_user)
 
 
         # after making sure we have enough inventory and creating an inventory update (which create a user_activities entry for us)
@@ -670,7 +670,7 @@ def get_inventory_updates(type: Optional[models.InventoryUpdateType] = Query(Non
 
 # endregion
 # region User Activities CRUD
-def create_user_activity(user_activity: UserActivityCreate, db: Session, current_user: UserToReturn = Depends(get_current_user)):
+def create_user_activity(user_activity: UserActivityCreate, db: Session, current_user: UserToReturn):
 
     # Create a new UserActivity instance
     db_user_activity = models.UserActivity(

--- a/backend/api_server/backend.py
+++ b/backend/api_server/backend.py
@@ -581,7 +581,7 @@ def fill_prescription(prescription_id: int, db: Session = Depends(get_db), curre
             quantity_changed_by= - db_prescription.quantity,
             # no transaction_id since this is not associated with a transaction
             # TODO: is this right? or should we do "Fill prescription"
-            type=models.InventoryUpdateType.FILL_PRESCRIPTION   # set the type to fill prescription
+            type=models.InventoryUpdateType.FILLPRESC   # set the type to fill prescription
         )
 
         # send the inventory_update_request to actually be stored in the database

--- a/backend/api_server/backend.py
+++ b/backend/api_server/backend.py
@@ -577,7 +577,8 @@ def fill_prescription(prescription_id: int, db: Session = Depends(get_db), curre
         # if we successfully deduct medication from inventory, create an inventory update instance in InventoryUpdate table
         inventory_update_request = models.InventoryUpdate(
             medication_id=db_medication.id,
-            quantity_changed_by=db_prescription.quantity,       # The quantity deducted
+            # The quantity deducted - make it negative since we want it to be a delta of e.g. -20, instead of 20
+            quantity_changed_by= - db_prescription.quantity,
             # no transaction_id since this is not associated with a transaction
             # TODO: is this right? or should we do "Fill prescription"
             type=models.InventoryUpdateType.FILL_PRESCRIPTION   # set the type to fill prescription

--- a/backend/api_server/backend.py
+++ b/backend/api_server/backend.py
@@ -671,13 +671,11 @@ def get_inventory_updates(type: Optional[models.InventoryUpdateType] = Query(Non
 # endregion
 # region User Activities CRUD
 def create_user_activity(user_activity: UserActivityCreate, db: Session, current_user: UserToReturn = Depends(get_current_user)):
-    # get user_id from current_user
-    # TODO: should I be explicitly passing current_user here?
-    user_details = read_users_me(current_user=current_user)
 
     # Create a new UserActivity instance
     db_user_activity = models.UserActivity(
-        user_id=user_details.id,
+        # get user_id from current_user
+        user_id=current_user.id,
         activity=user_activity.activity,
         timestamp=datetime.now(timezone.utc) # set the timestamp in UTC so timezones don't affect it
     )

--- a/backend/api_server/schema.py
+++ b/backend/api_server/schema.py
@@ -205,7 +205,7 @@ class PrescriptionUpdate(BaseModel):
 
 
 # endregion
-# Region Inventory Updates
+# region Inventory Updates
 class InventoryUpdateCreate(BaseModel):
     medication_id: int
     # get user_id from token

--- a/backend/api_server/schema.py
+++ b/backend/api_server/schema.py
@@ -228,11 +228,11 @@ class InventoryUpdateResponse(BaseModel):
 # endregion
 # region User Activities
 class UserActivityCreate(BaseModel):
-    activity: str
+    type: str # the activity type, an enum which can be "Login", "Logout", "Unlock Account", "Inventory Update"
     # TODO: let the database set the timestamp to the current time?
 
 class UserActivityResponse(BaseModel):
     id: int
     user_id: int
-    activity: str
+    type: str # the activity type, an enum
     timestamp: datetime

--- a/backend/api_server/schema.py
+++ b/backend/api_server/schema.py
@@ -170,7 +170,8 @@ class PrescriptionResponse(BaseModel):
 
 class PrescriptionCreate(BaseModel):
     patient_id: int
-    user_entered_id: int
+    # user_id comes from the token
+    # user_entered_id: int
     # TODO: i don't think you should be allowed to create an already filled prescription right away
     # it makes more sense to make them call the fill prescription route after creating the prescription
     # user_filled_id: Optional[int] = None

--- a/backend/api_server/schema.py
+++ b/backend/api_server/schema.py
@@ -189,7 +189,10 @@ class PrescriptionCreate(BaseModel):
 # make sense to edit info after the patients already has the medication
 class PrescriptionUpdate(BaseModel):
     patient_id: Optional[int] = None
-    user_entered_id: Optional[int] = None
+    # Not allowing user to change who entered the prescription, this comes from the token anyways
+    # to see who modified a prescription, look at user_activities
+    # user_entered_id: Optional[int] = None
+
     # I think you should have to call the fill prescription route to edit these
     # so we can have control over checking if we're able to fill the prescription
     # user_filled_id: Optional[int] = None

--- a/backend/api_server/schema.py
+++ b/backend/api_server/schema.py
@@ -184,6 +184,9 @@ class PrescriptionCreate(BaseModel):
     class Config:
         orm_mode = True
 
+# **NOTE: prescriptions are only able to be edited until they are filled
+# since we rely on the prescription to store important information and it doesn't
+# make sense to edit info after the patients already has the medication
 class PrescriptionUpdate(BaseModel):
     patient_id: Optional[int] = None
     user_entered_id: Optional[int] = None

--- a/backend/database/canned data.sql
+++ b/backend/database/canned data.sql
@@ -142,17 +142,17 @@ VALUES('Levothyroxine', '75 mg', 300, TRUE, '2026-01-01', 0.55);
 INSERT INTO prescriptions (patient_id, user_entered_id, user_filled_id, date_prescribed, filled_timestamp, medication_id, doctor_name, quantity) 
 VALUES (1, 3, 1, '2024-09-28', '2024-09-30 09:22:13', 2, 'Dr. Matthews', 50);
 INSERT INTO prescriptions (patient_id, user_entered_id, user_filled_id, date_prescribed, filled_timestamp, medication_id, doctor_name, quantity) 
-VALUES (2, 17, 5, '2024-09-10', '2024-09-12 11:18:45', 3, 'Dr. Philips', 20);
+VALUES (2, 17, null, '2024-09-10', null, 3, 'Dr. Philips', 20);
 INSERT INTO prescriptions (patient_id, user_entered_id, user_filled_id, date_prescribed, filled_timestamp, medication_id, doctor_name, quantity) 
 VALUES (3, 21, 24, '2024-08-05', '2024-08-06 14:47:59', 6, 'Dr. Greene', 100);
 INSERT INTO prescriptions (patient_id, user_entered_id, user_filled_id, date_prescribed, filled_timestamp, medication_id, doctor_name, quantity) 
 VALUES (1, 10, 10, '2024-09-29', '2024-09-30 12:10:22', 2, 'Dr. Stanley', 500);
 INSERT INTO prescriptions (patient_id, user_entered_id, user_filled_id, date_prescribed, filled_timestamp, medication_id, doctor_name, quantity) 
-VALUES (17, 12, 14, '2024-09-01', '2024-09-02 10:03:11', 7, 'Dr. Wills', 200);
+VALUES (17, 12, null, '2024-09-01', null, 7, 'Dr. Wills', 200);
 INSERT INTO prescriptions (patient_id, user_entered_id, user_filled_id, date_prescribed, filled_timestamp, medication_id, doctor_name, quantity) 
 VALUES (1, 11, 17, '2024-07-15', '2024-07-17 09:35:44', 11, 'Dr. Matthews', 50);
 INSERT INTO prescriptions (patient_id, user_entered_id, user_filled_id, date_prescribed, filled_timestamp, medication_id, doctor_name, quantity) 
-VALUES (5, 12, 21, '2024-09-25', '2024-09-26 14:22:30', 15, 'Dr. Hall', 12);
+VALUES (5, 12, null, '2024-09-25', null, 15, 'Dr. Hall', 12);
 INSERT INTO prescriptions (patient_id, user_entered_id, user_filled_id, date_prescribed, filled_timestamp, medication_id, doctor_name, quantity) 
 VALUES (16, 22, 24, '2024-09-29', '2024-09-30 15:45:15', 17, 'Dr. Squatch', 1000);
 INSERT INTO prescriptions (patient_id, user_entered_id, user_filled_id, date_prescribed, filled_timestamp, medication_id, doctor_name, quantity) 
@@ -160,11 +160,11 @@ VALUES (17, 6, 5, '2024-09-29', '2024-09-30 12:10:22', 2, 'Dr. Oz', 25);
 INSERT INTO prescriptions (patient_id, user_entered_id, user_filled_id, date_prescribed, filled_timestamp, medication_id, doctor_name, quantity) 
 VALUES (17, 1, 9, '2024-09-01', '2024-09-02 10:03:11', 7, 'Dr. Oz', 200);
 INSERT INTO prescriptions (patient_id, user_entered_id, user_filled_id, date_prescribed, filled_timestamp, medication_id, doctor_name, quantity) 
-VALUES (21, 19, 10, '2024-07-15', '2024-09-17 11:34:44', 15, 'Dr. Doofenschmirz', 12);
+VALUES (21, 19, null, '2024-07-15', null, 15, 'Dr. Doofenschmirz', 12);
 INSERT INTO prescriptions (patient_id, user_entered_id, user_filled_id, date_prescribed, filled_timestamp, medication_id, doctor_name, quantity) 
 VALUES (20, 24, 14, '2024-09-02', '2024-09-26 14:42:30', 2, 'Dr. Hall', 12);
 INSERT INTO prescriptions (patient_id, user_entered_id, user_filled_id, date_prescribed, filled_timestamp, medication_id, doctor_name, quantity) 
-VALUES (21, 2, 1, '2024-09-29', '2024-09-30 15:12:15', 17, 'Dr. Carter', 90);
+VALUES (21, 2, null, '2024-09-29', null, 17, 'Dr. Carter', 90);
 
 
 -- user_activities table


### PR DESCRIPTION
# Quick summary of some changes:

- Can't edit a prescription after it's been filled because that doesn't make sense and we rely on the prescription to store important details that we reference in multiple places
- Can't edit user_filled_id in a prescription, otherwise a user could make it look like someone else did the filling action
- getting the user_id in create_prescription() from the user's token and not from the request body, so they can't just say a random user_id
- fixing some references to enums
- changing how arguments get passed to some of the backend functions I wrote that can't be directly called as an endpoint